### PR TITLE
Generate reports automatically from YAML data file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - 2.7
+sudo: false
+install:
+  - pip install jinja2 PyYAML
+script:
+  - "build/build && if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ]; then build/upload; fi"
+notifications:
+  email:
+    - remirampin@gmail.com

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A comprehensive list of top computer science conferences and journals, with an enphasis on reproducibility efforts.
 
-## [Conferences](conferences.md)
-## [Journals](journals.md)
+## [Conferences](https://github.com/VickySteeves/list-awesome-cs-conferences-journals/blob/reports/conferences.md)
+## [Journals](https://github.com/VickySteeves/list-awesome-cs-conferences-journals/blob/reports/journals.md)
 
 # Contribute
 
 Please add to this list any journal or conference you think is noteworthy. Another really helpful contribution would be to help me sort both the list of journals and the list of conferences by sub-domain!
 
-In time more attributes will be listed for each item, and machine readable formats will be added. Stay tuned!
+Note that the markdown file on the `reports` branch are auto-generated from the data on the `master` branch. Please don't submit changes to the reports, but rather [edit the data](https://github.com/VickySteeves/list-awesome-cs-conferences-journals/edit/master/venues.yaml) directly!

--- a/build/build
+++ b/build/build
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+import io
+from jinja2 import Environment, FileSystemLoader
+import logging
+import os
+import yaml
+
+
+def render(template, filename, data):
+    with io.open('target/%s' % filename, 'w', encoding='utf-8') as fp:
+        for chunk in template.generate(data):
+            fp.write(chunk)
+
+
+def main():
+    template_env = Environment(loader=FileSystemLoader('build/'))
+
+    with open('venues.yaml') as fp:
+        venues = yaml.load(fp)
+    logging.info("Processing %d venues", len(venues))
+
+    with open('tags.yaml') as fp:
+        tags = yaml.load(fp)
+    tags = tags or {}
+    for k, v in tags.iteritems():
+        v['tag'] = k
+        v['venues'] = []
+    logging.info("Loaded %d tags", len(tags))
+
+    conferences = []
+    conferences_repro = []
+    conferences_others = []
+    journals = []
+    journals_repro = []
+    journals_others = []
+
+    for venue in sorted(venues, key=lambda v: v['name']):
+        new_tags = []
+        for tag in venue.get('tags', None) or ():
+            try:
+                new_tags.append(tags[tag])
+            except KeyError:
+                logging.warning("Venue %s has unknown tag %s",
+                                venue['name'], tag)
+            else:
+                tags[tag]['venues'].append(venue)
+        venue['tags'] = new_tags
+
+        if venue['type'] == 'conference':
+            conferences.append(venue)
+            if venue.get('reproducibility-review', False):
+                conferences_repro.append(venue)
+            else:
+                conferences_others.append(venue)
+        elif venue['type'] == 'journal':
+            journals.append(venue)
+            if venue.get('reproducibility-review', False):
+                journals_repro.append(venue)
+            else:
+                journals_others.append(venue)
+
+    logging.info("%d conferences, %d journals",
+                 len(conferences), len(journals))
+
+    if not os.path.isdir('target'):
+        os.mkdir('target')
+
+    report_md = template_env.get_template('report.md.tpl')
+    render(report_md, 'conferences.md', {'title': "Top Conferences",
+                                         'venues': conferences})
+    render(report_md, 'journals.md', {'title': "Top Journals",
+                                      'venues': journals})
+
+    sections_md = template_env.get_template('report_sections.md.tpl')
+    render(sections_md, 'repro-conferences.md',
+           {'sections': [
+               {'title': "Conferences with Reproducibility Review",
+                'venues': conferences_repro},
+               {'title': "Other Top Conferences",
+                'venues': conferences_others}]})
+    render(sections_md, 'repro-journals.md',
+           {'sections': [
+               {'title': "Journals with Reproducibility Review",
+                'venues': journals_repro},
+               {'title': "Other Top Jounals",
+                'venues': journals_others}]})
+
+    if not os.path.isdir('target/tags'):
+        os.mkdir('target/tags')
+
+    tag_md = template_env.get_template('tag.md.tpl')
+    for tag in tags.itervalues():
+        render(tag_md,
+               'tags/%s.md' % tag['tag'],
+               {'tag': tag})
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/build/report.md.tpl
+++ b/build/report.md.tpl
@@ -1,0 +1,4 @@
+{% if title %}# {{ title }}{% endif %}
+{% for venue in venues %}
+* [{{ venue.name }}]({{ venue.link }}){% if venue.tags %}<br>
+{% for tag in venue.tags %}[{{ tag.text }}](tags/{{ tag.tag }}.md){% endfor %}{% endif %}{% endfor %}

--- a/build/report_sections.md.tpl
+++ b/build/report_sections.md.tpl
@@ -1,0 +1,8 @@
+{% if title %}# {{ title }}
+
+{% endif %}{% for section in sections %}## {{ section.title }}
+{% for venue in section.venues %}
+* [{{ venue.name }}]({{ venue.link }}){% if venue.tags %}<br>
+{% for tag in venue.tags %}{{ tag.text }}{% endfor %}{% endif %}{% endfor %}
+
+{% endfor %}

--- a/build/tag.md.tpl
+++ b/build/tag.md.tpl
@@ -1,0 +1,4 @@
+# {{ tag.text }}
+{% for venue in tag.venues %}
+* [{{ venue.name }}]({{ venue.link }}){% if venue.tags %}<br>
+{% for vtag in venue.tags %}[{{ vtag.text }}](tags/{{ vtag.tag }}.md){% endfor %}{% endif %}{% endfor %}

--- a/build/upload
+++ b/build/upload
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+pip install ghp-import
+ghp-import -n target -b reports
+git push -qf https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git reports

--- a/venues.yaml
+++ b/venues.yaml
@@ -1,0 +1,394 @@
+- name: ECOOP
+  type: conference
+  link: http://2017.ecoop.org/track/ecoop-2017-Artifacts
+  reproducibility-review: true
+- name: ESEC/FSE
+  type: conference
+  link: http://esec-fse17.uni-paderborn.de/call_artifacts.php
+  reproducibility-review: true
+- name: HSCC
+  type: conference
+  link: http://www.cs.ox.ac.uk/conferences/hscc2016/re.html
+  reproducibility-review: true
+- name: ISSTA
+  type: conference
+  link: http://conf.researchr.org/track/issta-2017/issta-2017-artifacts
+  reproducibility-review: true
+- name: KDD
+  type: conference
+  link: http://www.kdd.org/kdd2017/calls/view/kdd-2017-call-for-research-papers
+  reproducibility-review: true
+  comments: |
+    they have a policy on reproducibility, but I'm not sure if they do a reproducibility evaluation
+- name: PLDI
+  type: conference
+  link: http://pldi17.sigplan.org/track/pldi-2017-artifact
+  reproducibility-review: true
+- name: POPL
+  type: conference
+  link: http://conf.researchr.org/track/POPL-2017/ArtifactEvaluation
+  reproducibility-review: true
+- name: SAS
+  type: conference
+  link: http://staticanalysis.org/sas2016/#artifact
+  reproducibility-review: true
+- name: SIGMOD
+  type: conference
+  link: http://db-reproducibility.seas.harvard.edu/
+  reproducibility-review: true
+- name: SPLASH
+  type: conference
+  link: http://2016.splashcon.org/track/splash-2016-artifacts
+  reproducibility-review: true
+- name: AAAI
+  type: conference
+  link: http://www.aaai.org/Conferences/AAAI/aaai17.php
+  reproducibility-review: false
+- name: ACL
+  type: conference
+  link: http://www.aclweb.org/portal/acl
+  reproducibility-review: false
+- name: AISTATS
+  type: conference
+  link: http://www.aaai.org/Conferences/AAAI/aaai17.php
+  reproducibility-review: false
+- name: ASPLOS
+  type: conference
+  link: https://www.ece.cmu.edu/calcm/asplos2016/
+  reproducibility-review: false
+- name: CCGRID
+  type: conference
+  link: https://www.arcos.inf.uc3m.es/wp/ccgrid2017/
+  reproducibility-review: false
+- name: COLING
+  type: conference
+  link: http://wikicfp.com/cfp/servlet/event.showcfp?eventid=50223
+  reproducibility-review: false
+- name: COLT
+  type: conference
+  link: http://www.learningtheory.org/
+  reproducibility-review: false
+- name: CONLL
+  type: conference
+  link: http://www.signll.org/conll
+  reproducibility-review: false
+- name: CVPR
+  type: conference
+  link: http://cvpr2017.thecvf.com/
+  reproducibility-review: false
+- name: EMNLP
+  type: conference
+  link: http://www.aclweb.org/portal/emnlp
+  reproducibility-review: false
+- name: Eurovis
+  type: conference
+  link: http://www.cs.rug.nl/jbi/eurovis2016/
+  reproducibility-review: false
+- name: FOSS4G
+  type: conference
+  link: http://2016.foss4g.org/
+  reproducibility-review: false
+- name: HiPC
+  type: conference
+  link: http://www.hipc.org/
+  reproducibility-review: false
+- name: HPDC
+  type: conference
+  link: http://hpdc.org/
+  reproducibility-review: false
+- name: ICCV
+  type: conference
+  link: http://www.wikicfp.com/cfp/servlet/event.showcfp?eventid=57716&copyownerid=92003
+  reproducibility-review: false
+- name: ICLR
+  type: conference
+  link: http://www.iclr.cc/
+  reproducibility-review: false
+- name: ICML
+  type: conference
+  link: http://www.wikicfp.com/cfp/servlet/event.showcfp?eventid=53557&copyownerid=84659
+  reproducibility-review: false
+- name: IJCAI
+  type: conference
+  link: https://www.ijcai.org/
+  reproducibility-review: false
+- name: Infovis vast chi
+  type: conference
+  link: http://ieeevis.org/
+  reproducibility-review: false
+- name: IUI
+  type: conference
+  link: https://iui.acm.org/
+  reproducibility-review: false
+- name: NAACL-HLT
+  type: conference
+  link: http://naacl.org/
+  reproducibility-review: false
+- name: NIPS
+  type: conference
+  link: https://nips.cc/
+  reproducibility-review: false
+- name: PDSW-DISCS
+  type: conference
+  link: http://www.pdsw.org/
+  reproducibility-review: false
+- name: PLDI
+  type: conference
+  link: http://conf.researchr.org/home/pldi-2017
+  reproducibility-review: false
+- name: PODC
+  type: conference
+  link: http://www.podc.org/
+  reproducibility-review: false
+- name: POPL
+  type: conference
+  link: http://conf.researchr.org/home/POPL-2017
+  reproducibility-review: false
+- name: SC
+  type: conference
+  link: http://www.supercomp.org/
+  reproducibility-review: false
+- name: SciVis
+  type: conference
+  link: http://ieeevis.org/year/2016/info/call-participation/scivis-papers
+  reproducibility-review: false
+- name: SIGCOMM
+  type: conference
+  link: http://www.sigcomm.org/
+  reproducibility-review: false
+- name: SIGGRAPH
+  type: conference
+  link: http://www.siggraph.org/
+  reproducibility-review: false
+- name: SIGGRAPH Asia
+  type: conference
+  link: https://sa2016.siggraph.org/
+  reproducibility-review: false
+- name: SIGMOD
+  type: journal
+  link: https://sigmod.org/
+  reproducibility-review: true
+- name: ACM TOMS
+  type: journal
+  link: http://toms.acm.org/
+  reproducibility-review: true
+- name: ACM TOMS
+  type: journal
+  link: http://toms.acm.org/
+  reproducibility-review: false
+- name: ACM Transactions on Algorithms
+  type: journal
+  link: http://talg.acm.org/
+  reproducibility-review: false
+- name: ACM Transactions on Database Systems
+  type: journal
+  link: https://tods.acm.org/
+  reproducibility-review: false
+- name: ACM Transactions on Graphics
+  type: journal
+  link: http://tog.acm.org/
+  reproducibility-review: false
+- name: ACM Transactions on Information Systems
+  type: journal
+  link: http://tois.acm.org/
+  reproducibility-review: false
+- name: Advances in Engineering Software
+  type: journal
+  link: https://www.journals.elsevier.com/advances-in-engineering-software
+  reproducibility-review: false
+- name: "CMES: Computer Modeling in Engineering and Sciences"
+  type: journal
+  link: http://www.scimagojr.com/journalsearch.php?q=28642&tip=sid
+  reproducibility-review: false
+- name: Communications of the ACM
+  type: journal
+  link: http://cacm.acm.org/
+  reproducibility-review: false
+- name: Computer Methods in Applied Mechanics and Engineering
+  type: journal
+  link: https://www.journals.elsevier.com/computer-methods-in-applied-mechanics-and-engineering
+  reproducibility-review: false
+- name: Computer Vision and Image Understanding
+  type: journal
+  link: https://www.journals.elsevier.com/computer-vision-and-image-understanding/
+  reproducibility-review: false
+- name: Computer-Aided Design
+  type: journal
+  link: https://www.journals.elsevier.com/computer-aided-design/
+  reproducibility-review: false
+- name: Computers & Chemical Engineering
+  type: journal
+  link: https://www.journals.elsevier.com/computers-and-chemical-engineering
+  reproducibility-review: false
+- name: Data & Knowledge Engineering
+  type: journal
+  link: https://www.journals.elsevier.com/data-and-knowledge-engineering/
+  reproducibility-review: false
+- name: Journal of Database Management
+  type: journal
+  link: http://www.igi-global.com/journal/journal-database-management-jdm/1072
+  reproducibility-review: false
+- name: Data & Knowledge Engineering Journal
+  type: journal
+  link: https://www.journals.elsevier.com/data-and-knowledge-engineering/
+  reproducibility-review: false
+- name: Database and Network Journal
+  type: journal
+  link: http://dl.acm.org/citation.cfm?id=J239
+  reproducibility-review: false
+- name: Distributed and Parallel Databases
+  type: journal
+  link: http://www.springer.com/computer/database+management+%26+information+retrieval/journal/10619
+  reproducibility-review: false
+- name: Environmental Modelling & Software
+  type: journal
+  link: https://www.journals.elsevier.com/environmental-modelling-and-software/
+  reproducibility-review: false
+- name: Foundations and Trends in Machine Learning
+  type: journal
+  link: http://dl.acm.org/citation.cfm?id=2185815
+  reproducibility-review: false
+- name: Foundations and Trends in Theoretical Computer Science
+  type: journal
+  link: http://www.nowpublishers.com/TCS
+  reproducibility-review: false
+- name: Geoinformatica
+  type: journal
+  link: http://link.springer.com/journal/10707
+  reproducibility-review: false
+- name: IBM Journal of Research and Development
+  type: journal
+  link: http://researchweb.watson.ibm.com/journal/rdindex.html
+  reproducibility-review: false
+- name: IEEE Communications Magazine
+  type: journal
+  link: http://www.comsoc.org/commag
+  reproducibility-review: false
+- name: IEEE Journal on Selected Areas in Communication
+  type: journal
+  link: http://www.comsoc.org/jsac
+  reproducibility-review: false
+- name: IEEE Transactions on Antennas and Propagation
+  type: journal
+  link: http://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8
+  reproducibility-review: false
+- name: IEEE Transactions on Communications
+  type: journal
+  link: http://www.comsoc.org/tc
+  reproducibility-review: false
+- name: IEEE Transactions on Information Theory
+  type: journal
+  link: http://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=18
+  reproducibility-review: false
+- name: IEEE Transactions on Software Engineering
+  type: journal
+  link: http://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=32
+  reproducibility-review: false
+- name: IEEE-ACM Transactions on Networking
+  type: journal
+  link: http://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=90
+  reproducibility-review: false
+- name: IEICE Data Engineering
+  type: journal
+  link: https://search.ieice.org/iss/
+  reproducibility-review: false
+- name: Information & Software Technology
+  type: journal
+  link: https://www.journals.elsevier.com/information-and-software-technology/
+  reproducibility-review: false
+- name: Information Processing Letters
+  type: journal
+  link: https://www.journals.elsevier.com/information-processing-letters/
+  reproducibility-review: false
+- name: Information Systems
+  type: journal
+  link: http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2575
+  reproducibility-review: false
+- name: International Journal of Information Technology
+  type: journal
+  link: http://www.worldscientific.com/worldscinet/ijitdm
+  reproducibility-review: false
+- name: International Journal of Computer & Information Sciences
+  type: journal
+  link: http://www.acisinternational.org/ijcis.html
+  reproducibility-review: false
+- name: International Journal of Geographic Information Systems
+  type: journal
+  link: http://www.tandfonline.com/loi/tgis20
+  reproducibility-review: false
+- name: International Journal of Intelligent & Cooperative Info. Systems
+  type: journal
+  link: http://www.worldscientific.com/worldscinet/ijcis
+  reproducibility-review: false
+- name: "Journal of Intell. Info Systems: Integrating AI and DB Tech"
+  type: journal
+  link: http://www.springer.com/computer/database+management+%26+information+retrieval/journal/10844
+  reproducibility-review: false
+- name: Journal of Systems Integration
+  type: journal
+  link: http://www.si-journal.org/
+  reproducibility-review: false
+- name: Journal of Data Mining & Knowledge Discovery
+  type: journal
+  link: https://link.springer.com/journal/10618
+  reproducibility-review: false
+- name: Journal of Combinatorics, Information and System Sciences
+  type: journal
+  link: http://www.worldcat.org/title/journal-of-combinatorics-information-system-sciences/oclc/3727676
+  reproducibility-review: false
+- name: Journal of Computer and System Sciences
+  type: journal
+  link: https://www.journals.elsevier.com/journal-of-computer-and-system-sciences
+  reproducibility-review: false
+- name: Journal of Data Warehousing
+  type: journal
+  link: http://www.igi-global.com/journal/international-journal-data-warehousing-mining/1085
+  reproducibility-review: false
+- name: Journal of Information Processing and Cybernetics
+  type: journal
+  link: http://dl.acm.org/citation.cfm?id=J260
+  reproducibility-review: false
+- name: Journal of Machine Learning Research
+  type: journal
+  link: http://www.jmlr.org/
+  reproducibility-review: false
+- name: Journal of the ACM
+  type: journal
+  link: http://jacm.acm.org/
+  reproducibility-review: false
+- name: Journal of the American Society for Information Science
+  type: journal
+  link: http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291532-2890
+  reproducibility-review: false
+- name: Journal on Digital Libraries
+  type: journal
+  link: http://link.springer.com/journal/799
+  reproducibility-review: false
+- name: SIAM Journal on Computing
+  type: journal
+  link: https://www.siam.org/journals/sicomp.php
+  reproducibility-review: false
+- name: SIAM Journal on Discrete Math
+  type: journal
+  link: https://www.siam.org/journals/sidma.php
+  reproducibility-review: false
+- name: SIAM Journal on Scientific Computing
+  type: journal
+  link: https://www.siam.org/journals/sisc.php
+  reproducibility-review: false
+- name: SIGMOD Record
+  type: journal
+  link: https://sigmodrecord.org/
+  reproducibility-review: false
+- name: Theoretical Computer Science
+  type: journal
+  link: https://www.journals.elsevier.com/theoretical-computer-science/
+  reproducibility-review: false
+- name: Theory of Computing
+  type: journal
+  link: http://theoryofcomputing.org/
+  reproducibility-review: false
+- name: VLDB International Journal
+  type: journal
+  link: http://link.springer.com/journal/778
+  reproducibility-review: false


### PR DESCRIPTION
This is over-engineered to the max. The master branch has a YAML file with info on each "venue", from which Travis creates whatever list we want in whatever format we want (markdown right now, but HTML could be added).

Right now generates:
* All conferences
* All journals
* Conferences separating with/without reproducibility review
* Journals separating with/without reproducibility review

There are also tags.

Needs Travis with a GH_TOKEN to push the generated files.

This should probably be kept for later, if and when we get more data in this.